### PR TITLE
Added GPL copyright notice

### DIFF
--- a/src/main/java/dk/philiphansen/craftech/CrafTech.java
+++ b/src/main/java/dk/philiphansen/craftech/CrafTech.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
 package dk.philiphansen.craftech;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/dk/philiphansen/craftech/blocks/BlockCobbleLimestone.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/BlockCobbleLimestone.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
 package dk.philiphansen.craftech.blocks;
 
 import net.minecraft.block.Block;

--- a/src/main/java/dk/philiphansen/craftech/blocks/BlockLimestone.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/BlockLimestone.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
 package dk.philiphansen.craftech.blocks;
 
 import java.util.Random;

--- a/src/main/java/dk/philiphansen/craftech/blocks/BlockLimestoneBrick.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/BlockLimestoneBrick.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
 package dk.philiphansen.craftech.blocks;
 
 import dk.philiphansen.craftech.reference.BlockInfo;

--- a/src/main/java/dk/philiphansen/craftech/blocks/ModBlocks.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/ModBlocks.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
 package dk.philiphansen.craftech.blocks;
 
 import net.minecraft.item.ItemStack;

--- a/src/main/java/dk/philiphansen/craftech/reference/BlockInfo.java
+++ b/src/main/java/dk/philiphansen/craftech/reference/BlockInfo.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
 package dk.philiphansen.craftech.reference;
 
 public class BlockInfo {

--- a/src/main/java/dk/philiphansen/craftech/reference/ModInfo.java
+++ b/src/main/java/dk/philiphansen/craftech/reference/ModInfo.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
 package dk.philiphansen.craftech.reference;
 
 public class ModInfo {

--- a/src/main/java/dk/philiphansen/craftech/world/GenerationHandler.java
+++ b/src/main/java/dk/philiphansen/craftech/world/GenerationHandler.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
 package dk.philiphansen.craftech.world;
 
 import java.util.Random;


### PR DESCRIPTION
Added the required copyright notice under the GPL license, this will need to be added to every source file.

An easy way to do that is the following:
1. In eclipse, go to `Window` -> `Preferences` -> `Java` -> `Code Style` -> `Code Templates`
2. Under `Code` edit `New Java File` to contain the following:
   
   ```
   ${filecomment}
   
   ${package_declaration}
   
   ${type_declaration}
   ```
3. Under `Comments` edit `Files` to contain the following:
   
   ```
   /*
   * This file is part of CrafTech.
   *
   *  CrafTech is free software: you can redistribute it and/or modify
   *  it under the terms of the GNU General Public License as published by
   *  the Free Software Foundation, either version 3 of the License, or
   *  (at your option) any later version.
   
   *  CrafTech is distributed in the hope that it will be useful,
   *  but WITHOUT ANY WARRANTY; without even the implied warranty of
   *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   *  GNU General Public License for more details.
   *
   *  You should have received a copy of the GNU General Public License
   *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
   */
   ```
   
   This will automatically insert the copyright notice into every new file created 

Also closes #3 
