### PR TITLE
Added config file for world generation

### DIFF
--- a/src/main/java/dk/philiphansen/craftech/CrafTech.java
+++ b/src/main/java/dk/philiphansen/craftech/CrafTech.java
@@ -17,6 +17,8 @@
 
 package dk.philiphansen.craftech;
 
+import net.minecraftforge.common.config.Configuration;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -27,6 +29,7 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import dk.philiphansen.craftech.blocks.ModBlocks;
+import dk.philiphansen.craftech.config.ConfigHandler;
 import dk.philiphansen.craftech.reference.ModInfo;
 import dk.philiphansen.craftech.world.GenerationHandler;
 
@@ -40,6 +43,8 @@ public class CrafTech {
     
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
+    	ConfigHandler.init(event.getSuggestedConfigurationFile());
+    	
     	ModBlocks.init();
     }
     

--- a/src/main/java/dk/philiphansen/craftech/config/ConfigHandler.java
+++ b/src/main/java/dk/philiphansen/craftech/config/ConfigHandler.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
+package dk.philiphansen.craftech.config;
+
+import java.io.File;
+
+import dk.philiphansen.craftech.reference.ConfigInfo;
+import dk.philiphansen.craftech.reference.GenerationInfo;
+import net.minecraftforge.common.config.Configuration;
+
+public class ConfigHandler {
+
+	public static void init(File file) {
+		Configuration config = new Configuration(file);
+		
+		config.load();
+		
+		GenerationInfo.LIMESTONE_VEIN_SIZE = config.get(ConfigInfo.WORLDGEN_CATEGORY, ConfigInfo.LIMESTONE + ": " + ConfigInfo.VEIN_SIZE, GenerationInfo.LIMESTONE_VEIN_SIZE_DEFAULT).getInt();
+		GenerationInfo.LIMESTONE_VEINS_PER_CHUNK = config.get(ConfigInfo.WORLDGEN_CATEGORY, ConfigInfo.LIMESTONE + ": " + ConfigInfo.VEIN_COUNT, GenerationInfo.LIMESTONE_VEINS_PER_CHUNK_DEFAULT).getInt();
+		GenerationInfo.LIMESTONE_HIGHEST_SPAWN = config.get(ConfigInfo.WORLDGEN_CATEGORY, ConfigInfo.LIMESTONE + ": " + ConfigInfo.HIGHEST_SPAWN, GenerationInfo.LIMESTONE_HIGHEST_SPAWN_DEFAULT).getInt();
+		GenerationInfo.LIMESTONE_LOWEST_SPAWN = config.get(ConfigInfo.WORLDGEN_CATEGORY, ConfigInfo.LIMESTONE + ": " + ConfigInfo.LOWEST_SPAWN, GenerationInfo.LIMESTONE_LOWEST_SPAWN_DEFAULT).getInt();
+		
+		config.save();
+	}
+	
+}

--- a/src/main/java/dk/philiphansen/craftech/reference/ConfigInfo.java
+++ b/src/main/java/dk/philiphansen/craftech/reference/ConfigInfo.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
+package dk.philiphansen.craftech.reference;
+
+public class ConfigInfo {
+	public static final String WORLDGEN_CATEGORY = "World Generation";
+	
+	public static final String VEIN_SIZE = "Vein Size";
+	public static final String VEIN_COUNT = "Veins Per Chunk";
+	public static final String HIGHEST_SPAWN = "Higest spawn";
+	public static final String LOWEST_SPAWN = "Lowest spawn";
+	
+	public static final String LIMESTONE = "Limestone";
+}

--- a/src/main/java/dk/philiphansen/craftech/reference/GenerationInfo.java
+++ b/src/main/java/dk/philiphansen/craftech/reference/GenerationInfo.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
+package dk.philiphansen.craftech.reference;
+
+public class GenerationInfo {
+	public static int LIMESTONE_VEIN_SIZE;
+	public static int LIMESTONE_VEINS_PER_CHUNK;
+	public static int LIMESTONE_HIGHEST_SPAWN;
+	public static int LIMESTONE_LOWEST_SPAWN;
+	
+	public static final int LIMESTONE_VEIN_SIZE_DEFAULT = 32;
+	public static final int LIMESTONE_VEINS_PER_CHUNK_DEFAULT = 30;
+	public static final int LIMESTONE_HIGHEST_SPAWN_DEFAULT = 128;
+	public static final int LIMESTONE_LOWEST_SPAWN_DEFAULT = 32;
+}

--- a/src/main/java/dk/philiphansen/craftech/world/GenerationHandler.java
+++ b/src/main/java/dk/philiphansen/craftech/world/GenerationHandler.java
@@ -27,13 +27,14 @@ import cpw.mods.fml.common.IWorldGenerator;
 import cpw.mods.fml.common.registry.GameRegistry;
 import dk.philiphansen.craftech.blocks.ModBlocks;
 import dk.philiphansen.craftech.reference.BlockInfo;
+import dk.philiphansen.craftech.reference.GenerationInfo;
 
 public class GenerationHandler implements IWorldGenerator{
 	private WorldGenerator generator;
 	
 	public GenerationHandler() {
 		GameRegistry.registerWorldGenerator(this, 0);
-		generator = new WorldGenMinable(ModBlocks.blockLimestone, 32);
+		generator = new WorldGenMinable(ModBlocks.blockLimestone, GenerationInfo.LIMESTONE_VEIN_SIZE);
 	}
 	
 	private void generateStandardOre(Random rand, int chunkX, int chunkZ, World world, int iterations, WorldGenerator gen, int lowestY, int highestY) {
@@ -48,6 +49,6 @@ public class GenerationHandler implements IWorldGenerator{
 
 	@Override
 	public void generate(Random random, int chunkX, int chunkZ, World world, IChunkProvider chunkGenerator, IChunkProvider chunkProvider) {
-		generateStandardOre(random, chunkX, chunkZ, world, 30, generator, 32, 128);
+		generateStandardOre(random, chunkX, chunkZ, world, GenerationInfo.LIMESTONE_VEINS_PER_CHUNK, generator, GenerationInfo.LIMESTONE_LOWEST_SPAWN, GenerationInfo.LIMESTONE_HIGHEST_SPAWN);
 	}
 }


### PR DESCRIPTION
The limestone vein size, number of veins per chunk, higest and lowest point a vein can spawn can now all be set in a config file.
Default values are the same as previously.

This should close #4 :smiley: 
