### PR TITLE
Blastfurnace Lighting

### DIFF
--- a/src/main/java/dk/philiphansen/craftech/tileentities/TileentityBlastFurnace.java
+++ b/src/main/java/dk/philiphansen/craftech/tileentities/TileentityBlastFurnace.java
@@ -189,10 +189,7 @@ public class TileentityBlastFurnace extends TileEntity implements IInventory{
 	@Override
 	public void updateEntity() {
 		if (!worldObj.isRemote) {
-			if (firstUpdate) {
-				firstUpdate = false;
-				updateBlockMeta();
-			}
+			updateBlockMeta();
 			if (running) {
 				processTimer++;
 				
@@ -219,13 +216,11 @@ public class TileentityBlastFurnace extends TileEntity implements IInventory{
 	private void startProcess() {
 		processTimer = 0;
 		running = true;
-		updateBlockMeta();
 	}
 	
 	private void stopProcess() {
 		running = false;
 		processTimer = 0;
-		updateBlockMeta();	
 	}
 	
 	public void updateBlockMeta() {


### PR DESCRIPTION
First try at fixing the Blast Furnace's lighting issues, this should close #12, if working properly.

The lighting is fixed by updating the tile entity's lighting and metadata every tile entity update - not an optimal method at all. So I'm thinking we need to look into other ways of doing this, but here's the start.
