### PR TITLE
Implements sided inventory to Blast Furnace

### DIFF
--- a/src/main/java/dk/philiphansen/craftech/tileentities/TileentityBlastFurnace.java
+++ b/src/main/java/dk/philiphansen/craftech/tileentities/TileentityBlastFurnace.java
@@ -17,6 +17,9 @@
 
 package dk.philiphansen.craftech.tileentities;
 
+import com.google.common.primitives.Ints;
+import com.sun.org.apache.xalan.internal.xsltc.util.IntegerArray;
+
 import dk.philiphansen.craftech.CrafTech;
 import dk.philiphansen.craftech.blocks.ModBlocks;
 import dk.philiphansen.craftech.items.ModItems;
@@ -24,6 +27,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -31,7 +35,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.EnumSkyBlock;
 
-public class TileentityBlastFurnace extends TileEntity implements IInventory{
+public class TileentityBlastFurnace extends TileEntity implements ISidedInventory{
 	
 	private ItemStack[] items;
 	private int processTimer;
@@ -143,6 +147,36 @@ public class TileentityBlastFurnace extends TileEntity implements IInventory{
 				return false;
 		}
 
+	}
+	
+	@Override
+	public int[] getAccessibleSlotsFromSide(int i) {
+		if (i == 0) {
+			return new int[]{3};
+		}
+		else {
+			return new int[]{0,1,2};
+		}
+	}
+
+	@Override
+	public boolean canInsertItem(int slot, ItemStack stack, int side) {
+		if (Ints.contains(getAccessibleSlotsFromSide(side), slot) && isItemValidForSlot(slot, stack)) {
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canExtractItem(int slot, ItemStack stack, int side) {
+		if (Ints.contains(getAccessibleSlotsFromSide(side), slot) && getStackInSlot(slot) == stack) {
+			return true;
+		}
+		else {
+			return false;
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
This should allow for users to properly use hoppers with the blast furnace to insert and extract items, without accidentally taking out the input or anything similar.

The rules are fairly simple:
- Bottom side is connected to output slot
- Top and sides are connected to input slots

Closes #11 
