### PR TITLE
Custom creative tab

### DIFF
--- a/src/main/java/dk/philiphansen/craftech/CrafTech.java
+++ b/src/main/java/dk/philiphansen/craftech/CrafTech.java
@@ -17,6 +17,7 @@
 
 package dk.philiphansen.craftech;
 
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraftforge.common.config.Configuration;
 
 import org.apache.logging.log4j.LogManager;
@@ -31,6 +32,7 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import dk.philiphansen.craftech.blocks.ModBlocks;
 import dk.philiphansen.craftech.config.ConfigHandler;
+import dk.philiphansen.craftech.creativetab.CreativeTabCrafTech;
 import dk.philiphansen.craftech.handler.GuiHandler;
 import dk.philiphansen.craftech.handler.ModFuelHandler;
 import dk.philiphansen.craftech.items.ModItems;
@@ -44,6 +46,8 @@ public class CrafTech {
     
     @Instance(ModInfo.MODID)
     public static CrafTech instance;
+    
+    public static CreativeTabs tabCrafTech = new CreativeTabCrafTech();
     
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {

--- a/src/main/java/dk/philiphansen/craftech/blocks/BlockBlastFurnace.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/BlockBlastFurnace.java
@@ -23,19 +23,16 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
-import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.common.network.internal.FMLNetworkHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -57,7 +54,7 @@ public class BlockBlastFurnace extends BlockContainer{
 	protected BlockBlastFurnace() {
 		super(Material.iron);
 		setBlockName(BlockInfo.BLAST_FURNACE_NAME);
-		setCreativeTab(CreativeTabs.tabDecorations);
+		setCreativeTab(CrafTech.tabCrafTech);
 		setHardness(3.5F);
 		setStepSound(soundTypePiston);
 	}

--- a/src/main/java/dk/philiphansen/craftech/blocks/BlockCoalCoke.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/BlockCoalCoke.java
@@ -17,17 +17,17 @@
 
 package dk.philiphansen.craftech.blocks;
 
-import dk.philiphansen.craftech.reference.BlockInfo;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.creativetab.CreativeTabs;
+import dk.philiphansen.craftech.CrafTech;
+import dk.philiphansen.craftech.reference.BlockInfo;
 
 public class BlockCoalCoke extends Block {
 
 	protected BlockCoalCoke() {
 		super(Material.rock);
 		setBlockName(BlockInfo.COALCOKE_BLOCK_NAME);
-		setCreativeTab(CreativeTabs.tabBlock);
+		setCreativeTab(CrafTech.tabCrafTech);
 		setHardness(2.0F);
 		setResistance(10.0F);
 		setStepSound(soundTypePiston);

--- a/src/main/java/dk/philiphansen/craftech/blocks/BlockCobbleLimestone.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/BlockCobbleLimestone.java
@@ -19,7 +19,7 @@ package dk.philiphansen.craftech.blocks;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.creativetab.CreativeTabs;
+import dk.philiphansen.craftech.CrafTech;
 import dk.philiphansen.craftech.reference.BlockInfo;
 
 public class BlockCobbleLimestone extends Block{
@@ -27,7 +27,7 @@ public class BlockCobbleLimestone extends Block{
 	protected BlockCobbleLimestone() {
 		super(Material.rock);
 		setBlockName(BlockInfo.COBBLE_LIMESTONE_NAME);
-		setCreativeTab(CreativeTabs.tabBlock);
+		setCreativeTab(CrafTech.tabCrafTech);
 		setHardness(2.0F);
 		setResistance(10.0F);
 		setStepSound(soundTypePiston);

--- a/src/main/java/dk/philiphansen/craftech/blocks/BlockCrusher.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/BlockCrusher.java
@@ -22,7 +22,6 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -55,7 +54,7 @@ public class BlockCrusher extends BlockContainer {
 	public BlockCrusher() {
 		super(Material.iron);
 		setBlockName(BlockInfo.CRUSHER_NAME);
-		setCreativeTab(CreativeTabs.tabDecorations);
+		setCreativeTab(CrafTech.tabCrafTech);
 		setHardness(3.5F);
 		setStepSound(soundTypePiston);
 	}

--- a/src/main/java/dk/philiphansen/craftech/blocks/BlockLimestone.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/BlockLimestone.java
@@ -21,8 +21,8 @@ import java.util.Random;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
+import dk.philiphansen.craftech.CrafTech;
 import dk.philiphansen.craftech.reference.BlockInfo;
 
 public class BlockLimestone extends Block {
@@ -30,7 +30,7 @@ public class BlockLimestone extends Block {
 	protected BlockLimestone() {
 		super(Material.rock);
 		setBlockName(BlockInfo.LIMESTONE_NAME);
-		setCreativeTab(CreativeTabs.tabBlock);
+		setCreativeTab(CrafTech.tabCrafTech);
 		setHardness(1.5F);
 		setResistance(10.0F);
 		setStepSound(soundTypePiston);

--- a/src/main/java/dk/philiphansen/craftech/blocks/BlockLimestoneBrick.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/BlockLimestoneBrick.java
@@ -17,17 +17,17 @@
 
 package dk.philiphansen.craftech.blocks;
 
-import dk.philiphansen.craftech.reference.BlockInfo;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.creativetab.CreativeTabs;
+import dk.philiphansen.craftech.CrafTech;
+import dk.philiphansen.craftech.reference.BlockInfo;
 
 public class BlockLimestoneBrick extends Block{
 
 	protected BlockLimestoneBrick() {
 		super(Material.rock);
 		setBlockName(BlockInfo.LIMESTONE_BRICK_NAME);
-		setCreativeTab(CreativeTabs.tabBlock);
+		setCreativeTab(CrafTech.tabCrafTech);
 		setHardness(2.0F);
 		setResistance(10.0F);
 		setStepSound(soundTypePiston);

--- a/src/main/java/dk/philiphansen/craftech/creativetab/CreativeTabCrafTech.java
+++ b/src/main/java/dk/philiphansen/craftech/creativetab/CreativeTabCrafTech.java
@@ -1,0 +1,22 @@
+package dk.philiphansen.craftech.creativetab;
+
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import dk.philiphansen.craftech.blocks.ModBlocks;
+import dk.philiphansen.craftech.reference.ModInfo;
+
+public class CreativeTabCrafTech extends CreativeTabs {
+
+	public CreativeTabCrafTech() {
+		super(ModInfo.MODID);	
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public Item getTabIconItem() {
+		return Item.getItemFromBlock(ModBlocks.blockBlastFurnace);
+	}
+
+}

--- a/src/main/java/dk/philiphansen/craftech/creativetab/CreativeTabCrafTech.java
+++ b/src/main/java/dk/philiphansen/craftech/creativetab/CreativeTabCrafTech.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of CrafTech.
+ *
+ *  CrafTech is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+
+ *  CrafTech is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with CrafTech.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
 package dk.philiphansen.craftech.creativetab;
 
 import net.minecraft.creativetab.CreativeTabs;

--- a/src/main/java/dk/philiphansen/craftech/items/ItemCoalCoke.java
+++ b/src/main/java/dk/philiphansen/craftech/items/ItemCoalCoke.java
@@ -17,20 +17,15 @@
 
 package dk.philiphansen.craftech.items;
 
-import java.util.List;
-
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+import dk.philiphansen.craftech.CrafTech;
 import dk.philiphansen.craftech.reference.ItemInfo;
 
 public class ItemCoalCoke extends Item {
 	public ItemCoalCoke() {
 		super();
 		setUnlocalizedName(ItemInfo.COALCOKE_NAME);
-		this.setCreativeTab(CreativeTabs.tabMaterials);
+		this.setCreativeTab(CrafTech.tabCrafTech);
 		setTextureName(ItemInfo.TEXTURE_LOCATION + ":" + ItemInfo.COALCOKE_TEXTURE);
 	}
 }

--- a/src/main/java/dk/philiphansen/craftech/items/ItemCoalCokeDust.java
+++ b/src/main/java/dk/philiphansen/craftech/items/ItemCoalCokeDust.java
@@ -17,15 +17,15 @@
 
 package dk.philiphansen.craftech.items;
 
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
+import dk.philiphansen.craftech.CrafTech;
 import dk.philiphansen.craftech.reference.ItemInfo;
 
 public class ItemCoalCokeDust extends Item {
 	public ItemCoalCokeDust() {
 		super();
 		setUnlocalizedName(ItemInfo.COALCOKE_DUST_NAME);
-		this.setCreativeTab(CreativeTabs.tabMaterials);
+		this.setCreativeTab(CrafTech.tabCrafTech);
 		setTextureName(ItemInfo.TEXTURE_LOCATION + ":" + ItemInfo.COALCOKE_DUST_TEXTURE);
 	}
 }

--- a/src/main/java/dk/philiphansen/craftech/items/ItemIronDust.java
+++ b/src/main/java/dk/philiphansen/craftech/items/ItemIronDust.java
@@ -17,15 +17,15 @@
 
 package dk.philiphansen.craftech.items;
 
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
+import dk.philiphansen.craftech.CrafTech;
 import dk.philiphansen.craftech.reference.ItemInfo;
 
 public class ItemIronDust extends Item {
 	public ItemIronDust() {
 		super();
 		setUnlocalizedName(ItemInfo.IRON_DUST_NAME);
-		this.setCreativeTab(CreativeTabs.tabMaterials);
+		this.setCreativeTab(CrafTech.tabCrafTech);
 		setTextureName(ItemInfo.TEXTURE_LOCATION + ":" + ItemInfo.IRON_DUST_TEXTURE);
 	}
 }

--- a/src/main/java/dk/philiphansen/craftech/items/ItemLimestoneDust.java
+++ b/src/main/java/dk/philiphansen/craftech/items/ItemLimestoneDust.java
@@ -17,15 +17,15 @@
 
 package dk.philiphansen.craftech.items;
 
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
+import dk.philiphansen.craftech.CrafTech;
 import dk.philiphansen.craftech.reference.ItemInfo;
 
 public class ItemLimestoneDust extends Item {
 	public ItemLimestoneDust() {
 		super();
 		setUnlocalizedName(ItemInfo.LIMESTONE_DUST_NAME);
-		this.setCreativeTab(CreativeTabs.tabMaterials);
+		this.setCreativeTab(CrafTech.tabCrafTech);
 		setTextureName(ItemInfo.TEXTURE_LOCATION + ":" + ItemInfo.LIMESTONE_DUST_TEXTURE);
 	}
 }

--- a/src/main/resources/assets/craftech/lang/en_US.lang
+++ b/src/main/resources/assets/craftech/lang/en_US.lang
@@ -8,3 +8,4 @@ item.coalCoke.name=Coal Coke
 item.coalCokeDust.name=Coal Coke Dust
 item.ironDust.name=Iron Dust
 item.limestoneDust.name=Limestone Dust
+itemGroup.craftech=CrafTech


### PR DESCRIPTION
Moves all the CrafTech blocks and items into a new creative tab, for easier find of items, and later expansion.
Closes #29.
