### PR TITLE
Gradle changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,3 +42,9 @@ processResources
         exclude 'mcmod.info'
     }
 }
+task release(dependsOn: 'build')
+gradle.taskGraph.whenReady {taskGraph ->
+    if (!taskGraph.hasTask(release)) {
+        project.version = project.version + "-DEV"
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ archivesBaseName = "CrafTech"
 minecraft {
     version = "1.7.2-10.12.0.1031"
     assetDir = "eclipse/assets"
+	
+	replace '${version}', project.version
 }
 processResources
 {

--- a/src/main/java/dk/philiphansen/craftech/reference/ModInfo.java
+++ b/src/main/java/dk/philiphansen/craftech/reference/ModInfo.java
@@ -20,5 +20,5 @@ package dk.philiphansen.craftech.reference;
 public class ModInfo {
 	public static final String MODID = "craftech";
     public static final String NAME = "CrafTech";
-    public static final String VERSION = "0.1a2";
+    public static final String VERSION = "${version}";
 }


### PR DESCRIPTION
Currently this will replace the version number in the source code as well as the mcmod.info.

Experimented with adding a -Pdev argument to the build task, which would add "-DEV" to the end of the jar file, had issues with not properly replacing in the java source.
For now I'm not going to play around more with ForgeGradle, I've spent about 3 hours making it work, or trying to.

If anyone wants to help me out with the other two features as specified in #35, be my guest.
