### PR TITLE
Crusher recipe list

### DIFF
--- a/src/main/java/dk/philiphansen/craftech/CrafTech.java
+++ b/src/main/java/dk/philiphansen/craftech/CrafTech.java
@@ -17,19 +17,12 @@
 
 package dk.philiphansen.craftech;
 
-import net.minecraft.creativetab.CreativeTabs;
-import net.minecraftforge.common.config.Configuration;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.Mod.Instance;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
-import cpw.mods.fml.common.network.NetworkRegistry;
 import dk.philiphansen.craftech.blocks.ModBlocks;
 import dk.philiphansen.craftech.config.ConfigHandler;
 import dk.philiphansen.craftech.creativetab.CreativeTabCrafTech;
@@ -38,6 +31,9 @@ import dk.philiphansen.craftech.handler.ModFuelHandler;
 import dk.philiphansen.craftech.items.ModItems;
 import dk.philiphansen.craftech.reference.ModInfo;
 import dk.philiphansen.craftech.world.GenerationHandler;
+import net.minecraft.creativetab.CreativeTabs;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @Mod(modid = ModInfo.MODID, name = ModInfo.NAME, version = ModInfo.VERSION)
 public class CrafTech {
@@ -63,6 +59,7 @@ public class CrafTech {
     	
     	ModBlocks.initCrafting();
     	ModBlocks.initSmelting();
+        ModBlocks.initCrusher();
     	
     	ModItems.initCrafting();
     	ModItems.initSmelting();

--- a/src/main/java/dk/philiphansen/craftech/blocks/ModBlocks.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/ModBlocks.java
@@ -17,13 +17,14 @@
 
 package dk.philiphansen.craftech.blocks;
 
-import net.minecraft.init.Blocks;
-import net.minecraft.item.ItemStack;
 import cpw.mods.fml.common.registry.GameRegistry;
 import dk.philiphansen.craftech.items.ModItems;
+import dk.philiphansen.craftech.items.crafting.CrusherRecipes;
 import dk.philiphansen.craftech.reference.BlockInfo;
-import dk.philiphansen.craftech.tileentities.TileentityCrusher;
 import dk.philiphansen.craftech.tileentities.TileentityBlastFurnace;
+import dk.philiphansen.craftech.tileentities.TileentityCrusher;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
 
 public class ModBlocks {
 	
@@ -78,6 +79,12 @@ public class ModBlocks {
 	public static void initSmelting() {
 		GameRegistry.addSmelting(blockCobbleLimestone, new ItemStack(blockLimestone), 0.1F);
 	}
+
+    public static void  initCrusher() {
+        CrusherRecipes.getInstance().addRecipe(new ItemStack(ModBlocks.blockLimestone), new ItemStack(ModItems.limestoneDust));
+        CrusherRecipes.getInstance().addRecipe(new ItemStack(ModItems.coalCoke), new ItemStack(ModItems.coalCokeDust));
+        CrusherRecipes.getInstance().addRecipe(new ItemStack(Blocks.iron_ore), new ItemStack(ModItems.ironDust));
+    }
 	
 	public static void initTileentities() {
 		GameRegistry.registerTileEntity(TileentityCrusher.class, BlockInfo.CRUSHER_NAME);

--- a/src/main/java/dk/philiphansen/craftech/blocks/ModBlocks.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/ModBlocks.java
@@ -81,9 +81,9 @@ public class ModBlocks {
 	}
 
     public static void  initCrusher() {
-        CrusherRecipes.getInstance().addRecipe(new ItemStack(ModBlocks.blockLimestone), new ItemStack(ModItems.limestoneDust));
-        CrusherRecipes.getInstance().addRecipe(new ItemStack(ModItems.coalCoke), new ItemStack(ModItems.coalCokeDust));
-        CrusherRecipes.getInstance().addRecipe(new ItemStack(Blocks.iron_ore), new ItemStack(ModItems.ironDust));
+        CrusherRecipes.getInstance().addRecipe(new ItemStack(ModBlocks.blockLimestone), new ItemStack(ModItems.limestoneDust, 2));
+        CrusherRecipes.getInstance().addRecipe(new ItemStack(ModItems.coalCoke), new ItemStack(ModItems.coalCokeDust, 2));
+        CrusherRecipes.getInstance().addRecipe(new ItemStack(Blocks.iron_ore), new ItemStack(ModItems.ironDust, 2));
     }
 	
 	public static void initTileentities() {

--- a/src/main/java/dk/philiphansen/craftech/inventory/ModSlot.java
+++ b/src/main/java/dk/philiphansen/craftech/inventory/ModSlot.java
@@ -17,13 +17,10 @@
 
 package dk.philiphansen.craftech.inventory;
 
-import dk.philiphansen.craftech.blocks.ModBlocks;
 import dk.philiphansen.craftech.items.ModItems;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
+import dk.philiphansen.craftech.items.crafting.CrusherRecipes;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 public class ModSlot extends Slot{
@@ -45,7 +42,7 @@ public class ModSlot extends Slot{
 		case 2:
 			return stack.getItem() == ModItems.coalCokeDust;
 		case 3:
-			return stack.getItem() == Item.getItemFromBlock(Blocks.iron_ore) || stack.getItem() == Item.getItemFromBlock(ModBlocks.blockLimestone) || stack.getItem() == ModItems.coalCoke;
+			return CrusherRecipes.getInstance().hasCrusherRecipe(stack);
 	}
 	return false;
 	}

--- a/src/main/java/dk/philiphansen/craftech/items/crafting/CrusherRecipes.java
+++ b/src/main/java/dk/philiphansen/craftech/items/crafting/CrusherRecipes.java
@@ -61,4 +61,19 @@ public class CrusherRecipes {
             return false;
         }
     }
+
+    public boolean hasCrusherRecipe(ItemStack stack) {
+        Iterator iterator = crusherList.entrySet().iterator();
+        Entry entry;
+
+        while (iterator.hasNext()) {
+            entry = (Entry)iterator.next();
+
+            if (((ItemStack)entry.getKey()).getItem() == stack.getItem()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/dk/philiphansen/craftech/items/crafting/CrusherRecipes.java
+++ b/src/main/java/dk/philiphansen/craftech/items/crafting/CrusherRecipes.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of CrafTech.
+ *
+ * CrafTech is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CrafTech is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CrafTech.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package dk.philiphansen.craftech.items.crafting;
+
+import net.minecraft.item.ItemStack;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class CrusherRecipes {
+
+    private static final CrusherRecipes instance = new CrusherRecipes();
+
+    private Map crusherList = new HashMap();
+
+    public static CrusherRecipes getInstance() {
+        return instance;
+    }
+
+    public void addRecipe(ItemStack inputStack, ItemStack outputStack) {
+        crusherList.put(inputStack, outputStack);
+    }
+
+    public ItemStack getCrusherResult(ItemStack inputStack) {
+        Iterator iterator = crusherList.entrySet().iterator();
+        Entry entry;
+
+        do {
+            if (!iterator.hasNext()) {
+                return null;
+            }
+
+            entry = (Entry)iterator.next();
+
+        } while (!equals(inputStack, (ItemStack) entry.getKey()));
+
+        return (ItemStack)entry.getValue();
+    }
+
+    private boolean equals(ItemStack stack1, ItemStack stack2) {
+        if ((stack1.getItem() == stack2.getItem()) && (stack1.getItemDamage() == stack2.getItemDamage() || stack2.getItemDamage() == 32767)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/dk/philiphansen/craftech/tileentities/TileentityCrusher.java
+++ b/src/main/java/dk/philiphansen/craftech/tileentities/TileentityCrusher.java
@@ -17,19 +17,14 @@
 
 package dk.philiphansen.craftech.tileentities;
 
+import com.google.common.primitives.Ints;
+import dk.philiphansen.craftech.items.crafting.CrusherRecipes;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
 import net.minecraft.inventory.ISidedInventory;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
-
-import com.google.common.primitives.Ints;
-
-import dk.philiphansen.craftech.blocks.ModBlocks;
-import dk.philiphansen.craftech.items.ModItems;
 
 public class TileentityCrusher extends TileEntity implements ISidedInventory {
 
@@ -120,12 +115,8 @@ public class TileentityCrusher extends TileEntity implements ISidedInventory {
 	public boolean isItemValidForSlot(int slot, ItemStack stack) {
 		switch (slot) {
 			case 0:
-				if (stack.getItem() == Item.getItemFromBlock(Blocks.iron_ore)) {
-					return true;
-				} else if (stack.getItem() == Item.getItemFromBlock(ModBlocks.blockLimestone)) {
-					return true;
-				} else if (stack.getItem() == ModItems.coalCoke) {
-					return true;
+				if (CrusherRecipes.getInstance().hasCrusherRecipe(stack)) {
+                    return true;
 				} else {
 					return false;
 				}
@@ -190,7 +181,7 @@ public class TileentityCrusher extends TileEntity implements ISidedInventory {
 				}
 				
 				if (processTimer >= maxTime) {
-					completeProcess(getStackInSlot(0).getItem());
+					completeProcess(getStackInSlot(0));
 					
 					if (correctItemInSlot() && spaceForProcess()) {
 						startProcess();
@@ -206,7 +197,7 @@ public class TileentityCrusher extends TileEntity implements ISidedInventory {
 	
 	//Returns true or false based on if we have any of these items in slot 0
 	private boolean correctItemInSlot() {
-		if (getStackInSlot(0) != null && (getStackInSlot(0).getItem() == Item.getItemFromBlock(Blocks.iron_ore) || getStackInSlot(0).getItem() == Item.getItemFromBlock(ModBlocks.blockLimestone) || getStackInSlot(0).getItem() == ModItems.coalCoke)) {
+		if (getStackInSlot(0) != null && CrusherRecipes.getInstance().hasCrusherRecipe(getStackInSlot(0))) {
 			return true;
 		}
 		return false;
@@ -255,41 +246,19 @@ public class TileentityCrusher extends TileEntity implements ISidedInventory {
 	}
 	
 	//If the process has completed lets return the player the processed item
-	private void completeProcess(Item item) {
+	private void completeProcess(ItemStack stack) {
 		decrStackSize(0, 1);
-		
-		if (item != null && item == Item.getItemFromBlock(Blocks.iron_ore)) {
-			if (getStackInSlot(1) != null && getStackInSlot(1).getItem() == ModItems.ironDust) {
-				ItemStack stack = getStackInSlot(1);
-				
-				stack.stackSize += dustCount;
-				
-				setInventorySlotContents(1, stack);
-			} else {
-				setInventorySlotContents(1, new ItemStack(ModItems.ironDust, dustCount));
-			}
-		}
-		else if (item != null && item == Item.getItemFromBlock(ModBlocks.blockLimestone)) {
-			if (getStackInSlot(1) != null && getStackInSlot(1).getItem() == ModItems.limestoneDust) {
-				ItemStack stack = getStackInSlot(1);
-				
-				stack.stackSize += dustCount;
-				
-				setInventorySlotContents(1, stack);
-			} else {
-				setInventorySlotContents(1, new ItemStack(ModItems.limestoneDust, dustCount));
-			}
-		} else if (item != null && item == ModItems.coalCoke) {
-			if (getStackInSlot(1) != null && getStackInSlot(1).getItem() == ModItems.coalCokeDust) {
-				ItemStack stack = getStackInSlot(1);
-				
-				stack.stackSize += dustCount;
-				
-				setInventorySlotContents(1, stack);
-			} else {
-				setInventorySlotContents(1, new ItemStack(ModItems.coalCokeDust, dustCount));
-			}
-		}
+
+        if (stack != null && CrusherRecipes.getInstance().hasCrusherRecipe(stack)) {
+            if (getStackInSlot(1) != null && getStackInSlot(1).isItemEqual(CrusherRecipes.getInstance().getCrusherResult(stack))) {
+                ItemStack slotStack = getStackInSlot(1);
+                slotStack.stackSize += dustCount;
+
+                setInventorySlotContents(1, slotStack);
+            } else {
+                setInventorySlotContents(1, CrusherRecipes.getInstance().getCrusherResult(getStackInSlot(0)).copy());
+            }
+        }
 	}
 	
 	public int getTimer() {


### PR DESCRIPTION
Added a recipe list for the crusher, rather than the hard coded inputs / outputs, this allows to to add new recipes for the crusher, with a simple line in the ModBlocks class.

This should close #34 for the time being, as it doesn't seem to make sense to do the same for the blast furnace, which only has one possible recipe.
