### PR TITLE
Tech Table drops inventory when destroyed

### DIFF
--- a/src/main/java/dk/philiphansen/craftech/blocks/BlockTechTable.java
+++ b/src/main/java/dk/philiphansen/craftech/blocks/BlockTechTable.java
@@ -24,10 +24,14 @@ import dk.philiphansen.craftech.CrafTech;
 import dk.philiphansen.craftech.gui.GuiIds;
 import dk.philiphansen.craftech.reference.BlockInfo;
 import dk.philiphansen.craftech.tileentities.TileentityTechTable;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
@@ -75,5 +79,36 @@ public class BlockTechTable extends BlockContainer {
             FMLNetworkHandler.openGui(player, CrafTech.instance, GuiIds.TECH_TABLE, world, x, y, z);
         }
         return true;
+    }
+
+    @Override
+    public void breakBlock(World world, int x, int y, int z, Block block, int meta) {
+        TileEntity tileentity = world.getTileEntity(x, y, z);
+
+        if (tileentity != null && tileentity instanceof IInventory) {
+            IInventory inventory = (IInventory)tileentity;
+
+            for (int i = 0; i < inventory.getSizeInventory(); i++) {
+                ItemStack stack = inventory.getStackInSlotOnClosing(i);
+
+                if (stack != null) {
+                    float spawnX = x + world.rand.nextFloat();
+                    float spawnY = y + world.rand.nextFloat();
+                    float spawnZ = z + world.rand.nextFloat();
+
+                    EntityItem droppedItem = new EntityItem(world, spawnX, spawnY, spawnZ, stack);
+
+                    float mult = 0.05F;
+
+                    droppedItem.motionX = (-0.5F + world.rand.nextFloat()) * mult;
+                    droppedItem.motionY = (4 + world.rand.nextFloat()) * mult;
+                    droppedItem.motionZ = (-0.5F + world.rand.nextFloat()) * mult;
+
+                    world.spawnEntityInWorld(droppedItem);
+                }
+            }
+        }
+
+        super.breakBlock(world, x, y, z, block, meta);
     }
 }


### PR DESCRIPTION
Closes #42. 
Implements code from the blast furnace (Courtesy of Vswe's modding courses) to drop every itemstack in the tileentity inventory, when the block is destroyed.
